### PR TITLE
feat: Implement automatic player list persistence via localStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
                 <div style="background: rgba(255, 235, 59, 0.1); border: 2px solid #ffc107; border-radius: 15px; padding: 20px; margin-bottom: 25px;">
                     <h3 style="color: #f57c00; margin-bottom: 10px;">⚠️ Önemli Bilgi</h3>
                     <p style="color: #e65100; margin: 0; line-height: 1.6;">
-                        Tarayıcı kapatıldığında verileriniz kaybolur. Oyuncu listesini korumak için aşağıdaki yedekleme özelliklerini kullanın:
+                        Oyuncu listeniz artık tarayıcınıza otomatik olarak kaydedilmektedir. Tarayıcıyı kapatıp açtığınızda listeniz genellikle geri yüklenecektir. Ancak, farklı bir tarayıcıya veya cihaza veri taşımak ya da önemli verileriniz için ekstra bir güvence oluşturmak amacıyla aşağıdaki yedekleme özelliklerini kullanmaya devam edebilirsiniz.
                     </p>
                 </div>
 

--- a/teambuilder.js
+++ b/teambuilder.js
@@ -344,27 +344,49 @@ function displayTeams() {
     }, 300);
 }
 
-// Veri kaydetme (artık sadece geçici bellek)
+// Veri kaydetme (localStorage kullanarak)
 function savePlayers() {
-    // Sadece session süresince bellekte tut
-    window.playersStorage = {
-        players: JSON.stringify(players),
-        timestamp: Date.now()
-    };
+    try {
+        localStorage.setItem('teamBuilderPlayers', JSON.stringify(players));
+    } catch (e) {
+        console.error("Error saving players to localStorage:", e);
+        // Optionally, inform the user if saving fails, though console error might be sufficient for now.
+        // showCustomAlert("Kaydetme Hatası", "Oyuncu listesi tarayıcıda otomatik olarak kaydedilemedi. Yedekleme özelliğini kullanmayı düşünebilirsiniz.", "error");
+    }
 }
 
-// Veri yükleme (sadece session süresince)
+// Veri yükleme (localStorage kullanarak)
 function loadPlayers() {
-    // Session boyunca bellekte tutulan veriyi yükle
-    if (window.playersStorage && window.playersStorage.players) {
-        try {
-            players = JSON.parse(window.playersStorage.players);
-            renderPlayersTable();
-        } catch(e) {
-            console.log('Veri yüklenirken hata oluştu');
+    try {
+        const storedPlayers = localStorage.getItem('teamBuilderPlayers');
+        if (storedPlayers) {
+            const parsedPlayers = JSON.parse(storedPlayers);
+            if (Array.isArray(parsedPlayers)) {
+                // Perform a basic validation of player structure if necessary
+                // For example, check if each player has 'id', 'name', 'power', 'position', 'available'
+                players = parsedPlayers.filter(p =>
+                    typeof p === 'object' && p !== null &&
+                    'id' in p && 'name' in p &&
+                    'power' in p && 'position' in p && 'available' in p
+                );
+                if (players.length !== parsedPlayers.length) {
+                    console.warn("Some invalid player objects were filtered out during loading.");
+                }
+            } else {
+                console.warn("Stored player data is not an array. Initializing with empty list.");
+                players = [];
+            }
+        } else {
+            // No data in localStorage, initialize with empty list
             players = [];
         }
+    } catch (e) {
+        console.error("Error loading players from localStorage:", e);
+        players = []; // Default to empty list on error
+        // Optionally, inform the user if loading fails
+        // showCustomAlert("Yükleme Hatası", "Oyuncu listesi tarayıcıdan yüklenemedi. Veriler bozulmuş olabilir.", "error");
     }
+    // Note: renderPlayersTable() and updateStats() are called in DOMContentLoaded after this.
 }
 
 // Enter tuşu ile oyuncu ekleme


### PR DESCRIPTION
This commit introduces automatic saving of the player list to the browser's localStorage. You will no longer lose your player data when closing and reopening the browser.

Key changes:

1.  **`savePlayers()` Modified (`teambuilder.js`):**
    - The function now serializes the `players` array and stores it in `localStorage` under the key `teamBuilderPlayers`.

2.  **`loadPlayers()` Modified (`teambuilder.js`):**
    - The function now attempts to load and parse the player list from `localStorage` on page load.
    - Includes validation to ensure the loaded data is an array and that player objects have essential properties.
    - Defaults to an empty list if no data is found or if data is corrupted, logging errors/warnings to the console.

3.  **UI Text Updated (`index.html`):**
    - The informational text in the "Yedekleme" (Backup) tab has been updated. It now informs you that your player list is saved automatically in the browser, while still recommending manual backup features for transfers or extra safety.

I performed manual testing to verify:
- Player data (additions, edits, deletions) persists across browser sessions.
- Clearing `localStorage` results in a clean slate.
- Interactions with existing JSON export/import and text backup/restore features function correctly, with `localStorage` reflecting the latest state.
- Graceful handling of empty or potentially corrupted `localStorage` data.